### PR TITLE
Account for motor controllers on protocols; fewer statics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .project
 build.xml
 build.properties
+.settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bin/
+.classpath
+.properties
+.project
+build.xml
+build.properties

--- a/org/usfirst/frc/team435/robot/FunctionalRobotDrive.java
+++ b/org/usfirst/frc/team435/robot/FunctionalRobotDrive.java
@@ -1,0 +1,18 @@
+package org.usfirst.frc.team435.robot;
+
+import java.util.function.Function;
+
+import edu.wpi.first.wpilibj.RobotDrive;
+import edu.wpi.first.wpilibj.SpeedController;
+
+public class FunctionalRobotDrive extends RobotDrive {
+
+	public FunctionalRobotDrive(SpeedController left, SpeedController right) {
+		super(left, right);
+	}
+	
+	public void functionalArcadeDrive(Double x, Double y, Function<Double, Double> mapping) {
+		arcadeDrive(mapping.apply(x), mapping.apply(y));
+	}
+
+}

--- a/org/usfirst/frc/team435/robot/MotorManager.java
+++ b/org/usfirst/frc/team435/robot/MotorManager.java
@@ -1,0 +1,79 @@
+package org.usfirst.frc.team435.robot;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import edu.wpi.first.wpilibj.CANSpeedController;
+import edu.wpi.first.wpilibj.SafePWM;
+import edu.wpi.first.wpilibj.SpeedController;
+
+public class MotorManager {
+
+	// Made up this number. What's the highest possible?
+	public static int MAX_CONTROLLER_ADDRESS = 256;
+
+	private static MotorManager instance;
+	private static Lock lock = new ReentrantLock();
+
+	enum MotorProtocol {
+		PWM, CAN;
+	}
+
+	SpeedController[][] controllers;
+
+	protected MotorManager() {
+		for (MotorProtocol proto : MotorProtocol.values()) {
+			controllers[proto.ordinal()] = new SpeedController[MAX_CONTROLLER_ADDRESS];
+		}
+	}
+
+	// Look up the Singleton pattern. We only want 1 instance of a motor
+	// manager ever declared. This is overkill, but it's the right way to
+	// do it. Ask if this is confusing.
+	public static MotorManager getMotorManager() {
+		if (instance == null) {
+			lock.lock();
+			if (instance == null) {
+				instance = new MotorManager();
+			}
+			lock.unlock();
+		}
+		return instance;
+	}
+
+	public SpeedController getSpeedController(
+			Class<? extends SpeedController> controllerClass, int channel) {
+		List<Class<?>> declared = Arrays.asList(controllerClass
+				.getDeclaredClasses());
+		MotorProtocol proto;
+		if (declared.contains(CANSpeedController.class)) {
+			proto = MotorProtocol.CAN;
+		} else if (declared.contains(SafePWM.class)) {
+			proto = MotorProtocol.PWM;
+		} else {
+			throw new RuntimeException("Not a PWM or CAN controller.... ");
+		}
+		SpeedController controller = controllers[MotorProtocol.CAN.ordinal()][channel];
+		if (controller == null) {
+			Constructor<? extends SpeedController> con;
+			try {
+				con = controllerClass
+						.getConstructor(Integer.TYPE);
+				return con.newInstance(channel);
+			} catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				e.printStackTrace();
+				throw new RuntimeException(e);
+			}
+			
+		} else {
+			// Can we do better?
+			throw new RuntimeException("Motor protocol/channel in use");
+		}
+
+	}
+
+}

--- a/org/usfirst/frc/team435/robot/MotorSet.java
+++ b/org/usfirst/frc/team435/robot/MotorSet.java
@@ -1,0 +1,18 @@
+package org.usfirst.frc.team435.robot;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import edu.wpi.first.wpilibj.SpeedController;
+
+public class MotorSet {
+
+	public List<SpeedController> speedControllers = new ArrayList<>(3);
+	
+	public void setSpeed(OI oi, Function<OI, Double> mapper) {
+		for (SpeedController speedController : speedControllers) {
+			speedController.set(mapper.apply(oi));
+		}
+	}
+}

--- a/org/usfirst/frc/team435/robot/Robot.java
+++ b/org/usfirst/frc/team435/robot/Robot.java
@@ -27,6 +27,8 @@ public class Robot extends IterativeRobot {
 	public static BoulderIntake boulderIntake = new BoulderIntake();
 
 	public static RobotLifter robotLifter = new RobotLifter();
+	
+	RobotMap roboMap = new RobotMap();
 
 	// Command autonomousCommand;
 	// SendableChooser chooser;
@@ -43,6 +45,8 @@ public class Robot extends IterativeRobot {
 		// chooser.addObject("My Auto", new MyAutoCommand());
 		// SmartDashboard.putData("Auto mode", chooser);
 		RobotMap.init();
+		roboMap = new RobotMap();
+		roboMap.initInstance();
 
 	}
 
@@ -107,8 +111,8 @@ public class Robot extends IterativeRobot {
 	public void teleopPeriodic() {
 		Scheduler.getInstance().run();
 		RobotMap.intakeMotor.set(oi.smoStick.getRawAxis(OI.BOULDER_INTAKE_AXIS));
-		RobotMap.leftBucketMotor.set(oi.smoStick.getRawAxis(OI.BUCKET_LIFT_AXIS));
-		RobotMap.rightBucketMotor.set(oi.smoStick.getRawAxis(OI.BUCKET_LIFT_AXIS));
+		
+		roboMap.getBoulderLift().setBucketSpeed(oi.smoStick.getRawAxis(OI.BUCKET_LIFT_AXIS));
 		if (oi.doubleSpeedButton.get())
 			RobotMap.drive.arcadeDrive(calc(oi.drivestick.getY()), calc(oi.drivestick.getX()));
 		else

--- a/org/usfirst/frc/team435/robot/Robot.java
+++ b/org/usfirst/frc/team435/robot/Robot.java
@@ -126,7 +126,7 @@ public class Robot extends IterativeRobot {
 			RobotMap.drive.functionalArcadeDrive(oi.drivestick.getY(), oi.drivestick.getY(), deadband);
 		}
 		else{
-			RobotMap.drive.functionalArcadeDrive(oi.drivestick.getY(), oi.drivestick.getY(), d -> d / 2);
+			RobotMap.drive.functionalArcadeDrive(oi.drivestick.getY(), oi.drivestick.getY(), d -> deadband.apply(d) / 2);
 		}
 		lifter.setSpeed(oi, oi -> oi.smoStick.getRawAxis(OI.END_GAME_UP_AXIS)
 				- oi.smoStick.getRawAxis(OI.END_GAME_DOWN_AXIS));

--- a/org/usfirst/frc/team435/robot/RobotMap.java
+++ b/org/usfirst/frc/team435/robot/RobotMap.java
@@ -32,9 +32,7 @@ public class RobotMap {
 	public static SpeedController leftMotor;
 	public static SpeedController rightMotor;
 
-	public static RobotDrive drive;
-	public static SpeedController liftMotor;
-	public static SpeedController liftMotorTwo;
+	public static FunctionalRobotDrive drive;
 
 	public static void init() {
 		MotorManager mgr = MotorManager.getMotorManager();
@@ -44,9 +42,7 @@ public class RobotMap {
 		
 		leftMotor = new CANTalon(LEFT_MOTOR);
 		rightMotor = new CANTalon(RIGHT_MOTOR);
-		drive = new RobotDrive(leftMotor, rightMotor);
-		liftMotor = new Victor(LIFT_MOTOR);
-		liftMotorTwo = new Jaguar(LIFT_MOTOR_TWO);
+		drive = new FunctionalRobotDrive(leftMotor, rightMotor);
 	}
 	
 	

--- a/org/usfirst/frc/team435/robot/RobotMap.java
+++ b/org/usfirst/frc/team435/robot/RobotMap.java
@@ -1,5 +1,7 @@
 package org.usfirst.frc.team435.robot;
 
+import org.usfirst.frc.team435.robot.subsystems.BoulderLift;
+
 import edu.wpi.first.wpilibj.CANTalon;
 import edu.wpi.first.wpilibj.Jaguar;
 import edu.wpi.first.wpilibj.RobotDrive;
@@ -20,11 +22,12 @@ public class RobotMap {
 	public static final int LIFT_MOTOR_TWO= 2;
 
 	public static SpeedController intakeMotor;
-	public static SpeedController leftBucketMotor;
-	public static SpeedController rightBucketMotor;
+
 	
 	public static final int LEFT_MOTOR = 0;
 	public static final int RIGHT_MOTOR = 1;
+	
+	protected BoulderLift boulderLift;
 
 	public static SpeedController leftMotor;
 	public static SpeedController rightMotor;
@@ -34,13 +37,25 @@ public class RobotMap {
 	public static SpeedController liftMotorTwo;
 
 	public static void init() {
-		intakeMotor = new CANTalon(INTAKE_MOTOR);
-		leftBucketMotor = new CANTalon(LEFT_BUCKET_MOTOR);
-		rightBucketMotor = new CANTalon(RIGHT_BUCKET_MOTOR);
+		MotorManager mgr = MotorManager.getMotorManager();
+		
+		intakeMotor = mgr.getSpeedController(CANTalon.class, INTAKE_MOTOR);
+		
+		
 		leftMotor = new CANTalon(LEFT_MOTOR);
 		rightMotor = new CANTalon(RIGHT_MOTOR);
 		drive = new RobotDrive(leftMotor, rightMotor);
 		liftMotor = new Victor(LIFT_MOTOR);
 		liftMotorTwo = new Jaguar(LIFT_MOTOR_TWO);
+	}
+	
+	
+	// eventually, all things should be instances.  Static is lazy/messy
+	public void initInstance() {
+		boulderLift = new BoulderLift();
+	}
+	
+	public BoulderLift getBoulderLift() {
+		return boulderLift;
 	}
 }

--- a/org/usfirst/frc/team435/robot/subsystems/BoulderLift.java
+++ b/org/usfirst/frc/team435/robot/subsystems/BoulderLift.java
@@ -1,5 +1,7 @@
 package org.usfirst.frc.team435.robot.subsystems;
 
+import java.util.function.Function;
+
 import org.usfirst.frc.team435.robot.RobotMap;
 
 import edu.wpi.first.wpilibj.CANTalon;
@@ -36,5 +38,9 @@ public class BoulderLift extends Subsystem {
     	leftBucketMotor.set(speed);
     	rightBucketMotor.set(speed);
     }
+    
+//    public void setSpeed(Function<Integer, Integer> mapping) {
+//    	mapping.apply(t)
+//    }
 }
 

--- a/org/usfirst/frc/team435/robot/subsystems/BoulderLift.java
+++ b/org/usfirst/frc/team435/robot/subsystems/BoulderLift.java
@@ -1,8 +1,9 @@
 package org.usfirst.frc.team435.robot.subsystems;
 
-import static org.usfirst.frc.team435.robot.RobotMap.leftBucketMotor;
-import static org.usfirst.frc.team435.robot.RobotMap.rightBucketMotor;
+import org.usfirst.frc.team435.robot.RobotMap;
 
+import edu.wpi.first.wpilibj.CANTalon;
+import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
@@ -10,19 +11,28 @@ import edu.wpi.first.wpilibj.command.Subsystem;
  */
 public class BoulderLift extends Subsystem {
 	
+	protected SpeedController leftBucketMotor;
+	protected SpeedController rightBucketMotor;
+	
+	public BoulderLift() {
+		super("BoulderLift");
+		leftBucketMotor = new CANTalon(RobotMap.LEFT_BUCKET_MOTOR);
+		rightBucketMotor = new CANTalon(RobotMap.RIGHT_BUCKET_MOTOR);
+	}
+	
     public void initDefaultCommand() {
     	
     }
-    
+        
     public void bucketDown(double speed){
-    	setBucket(Math.abs(speed));
+    	setBucketSpeed(Math.abs(speed));
     }
     
     public void bucketUp(double speed){
-    	setBucket(-Math.abs(speed));
+    	setBucketSpeed(-Math.abs(speed));
     }
     
-    private void setBucket(double speed){
+    public void setBucketSpeed(double speed){
     	leftBucketMotor.set(speed);
     	rightBucketMotor.set(speed);
     }

--- a/org/usfirst/frc/team435/robot/subsystems/RobotLifter.java
+++ b/org/usfirst/frc/team435/robot/subsystems/RobotLifter.java
@@ -1,8 +1,6 @@
 package org.usfirst.frc.team435.robot.subsystems;
 
 import edu.wpi.first.wpilibj.command.Subsystem;
-import static org.usfirst.frc.team435.robot.RobotMap.liftMotor;
-import static org.usfirst.frc.team435.robot.RobotMap.liftMotorTwo;
 
 
 
@@ -15,19 +13,19 @@ public class RobotLifter extends Subsystem {
     // here. Call these from Commands.
 	public void up(double speed)
 	{
-		liftMotor.set(speed);
-		liftMotorTwo.set(speed);
+//		liftMotor.set(speed);
+//		liftMotorTwo.set(speed);
 	}
 	public void down(double speed)
 	{
-		liftMotor.set(speed);
-		liftMotorTwo.set(speed);
+//		liftMotor.set(speed);
+//		liftMotorTwo.set(speed);
 	}
 
 	public void stay()
 	{
-		liftMotor.set(0);
-		liftMotorTwo.set(0);
+//		liftMotor.set(0);
+//		liftMotorTwo.set(0);
 	}
 
     public void initDefaultCommand() {

--- a/test/org/usfirst/frc/team435/robot/TestMotorTypes.java
+++ b/test/org/usfirst/frc/team435/robot/TestMotorTypes.java
@@ -1,0 +1,19 @@
+package org.usfirst.frc.team435.robot;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import edu.wpi.first.wpilibj.CANSpeedController;
+import edu.wpi.first.wpilibj.CANTalon;
+import edu.wpi.first.wpilibj.SpeedController;
+
+public class TestMotorTypes {
+
+	
+	@Test
+	public void isTalonCAN() {
+		SpeedController controller = new CANTalon(0);
+		Assert.assertTrue(controller instanceof CANSpeedController); 
+	}
+}


### PR DESCRIPTION
I don't actually expect you to grant this pull request.  It's more to show a few different things.

The issue that blocked us tonight is that we allow re-initialization of motor controllers on the same protocol/channel.  This is currently managed by sight (which is no good).  I've added a MotorManager class that takes a specified controller type & ID and creates one if nothing else is assigned.  Some additional work should be put into error handling.  But the idea is that we shouldn't have a jumbled mess of PWM and CAN id's... and certainly shouldn't be allowing re-initialization.

We're also using a lot of public static fields.  That really hurts your ability to control when things are initialized & effectively publishes partially initialized objects, which would be bad in a less robot-y environment.  I've modified how the bucked lifter works to demonstrate an instance-based approach.  I think it actually demonstrates how you can merge command-based and iterative-based robot code.

And I added a unit test.  But I couldn't run it because my stuff is out of date.  If somebody else can, please add a couple more to validate my assumptions about motor controllers and how to detect PWM vs CAN.

Feel free to ask questions.  I know there's some odd stuff in there.  And again, feel free to reject this pull request.  I'm not offended if you want only your code running.  And this is an incomplete conversion (that's totally untested).